### PR TITLE
Fixed regular expression for parsing uptime

### DIFF
--- a/src/zinfo_line
+++ b/src/zinfo_line
@@ -22,7 +22,7 @@ function _zinfo_line::formatted_date()
 #
 function _zinfo_line::formatted_uptime()
 {
-  uptime | sed 's!^.*up \([0-9]*\) day.*: \([0-9. ]*\)$!{\1d, \2}!'
+  uptime | sed 's!^[0-9: ]*up \([0-9a-z ]*\), [^:]*: \([0-9. ]*\)!{\1, \2}!'
 }
 
 #


### PR DESCRIPTION
This PR fixes regular expression for parsing `uptime` result.

Before this PR, input string must contains `day.*` pattern.
However, `mins` etc will be output if `uptime` was less than a day.
Then, this PR removes that restriction by including `day` , `mins` etc part in regular expression.

An example result of regular expression modified with this PR is shown below.

```
$ uptime
22:10  up 23 mins, 1 user, load averages: 1.87 2.77 2.50

# => {23 mins, 1.87 2.77 2.50}
```